### PR TITLE
Select prompt if value is not a valid option

### DIFF
--- a/addon/components/one-way-select.js
+++ b/addon/components/one-way-select.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { A as emberArray, isArray } from '@ember/array';
 import EmberObject, { computed, get, set } from '@ember/object';
-import { alias, empty, not, or } from '@ember/object/computed'
+import { alias, not, or } from '@ember/object/computed'
 import { isBlank, isNone, isPresent } from '@ember/utils';
 import { w } from '@ember/string';
 
@@ -62,7 +62,9 @@ const OneWaySelectComponent = Component.extend(DynamicAttributeBindings, {
     set(this, 'options', emberArray(options));
   },
 
-  nothingSelected: empty('selectedValue'),
+  nothingSelected: computed('selectedValue', function() {
+    return !this._findOption(this.get('selectedValue'));
+  }),
   promptIsDisabled: not('promptIsSelectable'),
   hasGrouping: or('optionsArePreGrouped', 'groupLabelPath'),
   computedOptionValuePath: or('optionValuePath', 'optionTargetPath'),

--- a/tests/integration/components/one-way-select-test.js
+++ b/tests/integration/components/one-way-select-test.js
@@ -402,3 +402,9 @@ test('allows to select blank without throwing', async function(assert) {
   assert.equal([...findAll('option')].find((o) => o.selected).textContent.trim(), 'myDefaultPrompt');
   assert.deepEqual(updates, ['one', undefined]);
 });
+
+test('Prompt is selected if value is not an option', function(assert) {
+  this.set('value', 'doesntexist');
+  this.render(hbs`{{one-way-select value=value options=options prompt="Select one"}}`);
+  assert.equal([...findAll('option')].find((o) => o.selected).textContent.trim(), 'Select one', 'Prompt is selected');
+});


### PR DESCRIPTION
Moved over from https://github.com/DockYard/ember-one-way-controls/pull/163, original message was

> Currently, a one-way-selects's prompt is only selected when the current value is empty. When value is not empty but also not a valid option, the browser initially renders the first passed option instead of the prompt, because none of the options have a selected attribute and the prompt itself has the disabled attribute.

> All that wouldn't be much of an issue if one doesn't pass invalid options, right? Well, it turns out that if value is an ember data relation, nothingSelected evaluates to false because it sees a promise. When the promise resolves to null, the first option stays selected because nothingSelected is still false (see #127 and probably also #159).

> Instead of using empty to determine nothingSelected, I'd propose checking if the passed value is actually a valid option. That doesn't only solve the first issue when an actually invalid option is passed, but also the second issue related to ember-data relations.