### PR TITLE
fix: remove unresolved import

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,2 +1,1 @@
 export { default as OneWaySelect } from './components/one-way-select';
-export { default as OneWayInput } from './components/one-way-input';


### PR DESCRIPTION
There doesn't seem to be a one-way-input component in this addon.