### PR TITLE
fix: replace deprecated hasBlock helper

### DIFF
--- a/addon/templates/components/one-way-select.hbs
+++ b/addon/templates/components/one-way-select.hbs
@@ -9,7 +9,7 @@
   {{#each this.optionGroups as |optionGroup groupIndex|}}
     <optgroup label={{optionGroup.groupName}}>
       {{#each optionGroup.options as |option index|}}
-        {{#if hasBlock}}
+        {{#if (has-block)}}
           <OneWaySelect::option
             @selected={{this.selectedValue}}
             @option={{option}}
@@ -33,7 +33,7 @@
   {{/each}}
 {{else}}
   {{#each this.options as |option index|}}
-    {{#if hasBlock}}
+    {{#if (has-block)}}
       <OneWaySelect::Option
           @selected={{this.selectedValue}}
           @option={{@option}}

--- a/addon/templates/components/one-way-select/option.hbs
+++ b/addon/templates/components/one-way-select/option.hbs
@@ -1,6 +1,6 @@
 <option value={{if @optionValuePath (get @option @optionValuePath) @option}}
         selected={{one-way-select/contains @selected @option @optionValuePath @optionTargetPath}}>
-  {{#if hasBlock}}
+  {{#if (has-block)}}
     {{yield}}
   {{else if @optionComponent}}
     {{component @optionComponent

--- a/package-lock.json
+++ b/package-lock.json
@@ -5898,9 +5898,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001154",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001154.tgz",
-      "integrity": "sha512-y9DvdSti8NnYB9Be92ddMZQrcOe04kcQtcxtBx4NkB04+qZ+JUWotnXBJTmxlKudhxNTQ3RRknMwNU2YQl/Org=="
+      "version": "1.0.30001292",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
+      "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
As of 3.x the [`{{hasBlock}}`](https://deprecations.emberjs.com/v3.x/#toc_has-block-and-has-block-params) is deprecated and should get replaced by the [`has-block` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/hasBlock?anchor=has-block).